### PR TITLE
[fix] Modify declaration of `char[]` template arguments, so they have external linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(render_context
         LANGUAGES C CXX
-        VERSION 0.2.4
+        VERSION 0.2.5
         DESCRIPTION "Utilities to render using Magnum with ImGUI integration")
 
 set(CMAKE_CXX_STANDARD 20)

--- a/src/render/context.h
+++ b/src/render/context.h
@@ -12,7 +12,7 @@
 
 namespace render {
     namespace units {
-        static constexpr char uv[] = "uv";
+        inline constexpr const char uv[] = "uv";
     }
 
     using UVCoordinates = math::types::NamedUnitT<float, units::uv>;

--- a/src/render/imgui/CMakeLists.txt
+++ b/src/render/imgui/CMakeLists.txt
@@ -1,18 +1,23 @@
 
 find_package(imgui REQUIRED)
 
-add_library(render_imgui INTERFACE)
+add_library(render_imgui
+        context.h
+        context.cpp
+        imconfig.h
+        pixels.hpp
+        )
 set_target_properties(render_imgui PROPERTIES
         PUBLIC_HEADER "context.h;imconfig.h;pixels.hpp"
         )
 target_link_libraries(render_imgui
-        INTERFACE
+        PUBLIC
         render
         imgui::imgui
         )
-target_include_directories(render_imgui INTERFACE "${CMAKE_CURRENT_LIST_DIR}/../..")
+target_include_directories(render_imgui PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../..")
 target_compile_definitions(render_imgui
-        INTERFACE
+        PUBLIC
         IMGUI_USER_CONFIG=\"${CMAKE_CURRENT_LIST_DIR}/imconfig.h\"
         )
 

--- a/src/render/imgui/context.cpp
+++ b/src/render/imgui/context.cpp
@@ -1,0 +1,98 @@
+#include "context.h"
+
+namespace render {
+
+    template<>
+    void drawCircle<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
+                                               const Magnum::Math::Vector2<imgui::Pixels> &center,
+                                               imgui::Pixels radius,
+                                               ImU32 color,
+                                               imgui::Pixels thickness) {
+        drawList.AddCircle(center, static_cast<float>(radius), color, 0, static_cast<float>(thickness));
+    }
+
+    template<>
+    void drawLine<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
+                                             const Magnum::Math::Vector2<imgui::Pixels> &start,
+                                             const Magnum::Math::Vector2<imgui::Pixels> &end,
+                                             ImU32 color,
+                                             imgui::Pixels thickness) {
+        drawList.AddLine(start, end, color, static_cast<float>(thickness));
+    }
+
+    template<>
+    void drawRectangle<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
+                                                  Magnum::Math::Range2D<imgui::Pixels> rectangle,
+                                                  ImU32 color,
+                                                  imgui::Pixels thickness) {
+        drawList.AddRect(rectangle.topLeft(), rectangle.bottomRight(), color, 0, 0, static_cast<float>(thickness));
+    }
+
+    template<>
+    void drawRectangleFilled<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
+                                                        Magnum::Math::Range2D<imgui::Pixels> rectangle,
+                                                        ImU32 color) {
+        drawList.AddRectFilled(rectangle.topLeft(), rectangle.bottomRight(), color);
+    }
+
+    template<>
+    void drawPolyline<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
+                                                 const std::vector<Magnum::Math::Vector2<imgui::Pixels>> &points_,
+                                                 ImU32 color,
+                                                 imgui::Pixels thickness,
+                                                 int flags) {
+        std::vector<ImVec2> points;
+        std::transform(points_.begin(), points_.end(), std::back_inserter(points), [&](auto &item) {
+            return Magnum::Vector2{item};
+        });
+        drawList.AddPolyline(points.data(), points.size(), color, flags, static_cast<float>(thickness));
+    }
+
+    template<>
+    void drawPolylineFilled<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
+                                                       std::vector<Magnum::Math::Vector2<imgui::Pixels>> points_,
+                                                       ImU32 color) {
+        std::vector<ImVec2> points;
+        std::transform(points_.begin(), points_.end(), std::back_inserter(points), [&](auto &item) {
+            return item;
+        });
+        drawList.AddConvexPolyFilled(points.data(), points.size(), color);
+    }
+
+    template<>
+    void drawText<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
+                                             Magnum::Math::Vector2<imgui::Pixels> position,
+                                             float fontSize,
+                                             ImU32 color,
+                                             const std::string &content) {
+        // TODO: If we want to rotate, we need to move vertices ourselves: https://gist.github.com/carasuca/e72aacadcf6cf8139de46f97158f790f
+        // TODO: Compute centered in a better way (use ImGui::CalcTextSize())
+        drawList.AddText(ImGui::GetFont(), fontSize, position, color, content.c_str());
+        /*
+        Magnum::Vector2 centered{
+                (float) position_.x() - (content.size() * fontSize_ / 4.f),
+                (float) position_.y() - (fontSize_ / 2.f),
+        };
+        auto position = _transform.transformPoint(Magnum::Vector2{centered});
+        float fontSize = (float) fontSize_ * _transform.uniformScaling();
+        drawList.AddText(ImGui::GetFont(), fontSize, position, color, content.c_str());
+         */
+    }
+
+    template<>
+    void drawImage<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
+                                              Magnum::GL::Texture2D &texture,
+                                              const Magnum::Math::Range2D<UVCoordinates> &uvCoords,
+                                              const std::array<Magnum::Math::Vector2<imgui::Pixels>, 4> &bbox) {
+        // Draw translated-rotated image: https://github.com/ocornut/imgui/issues/1982
+        ImVec2 uvs[4] = {Magnum::Math::Vector2<float>{uvCoords.topLeft()},
+                         Magnum::Math::Vector2<float>{uvCoords.topRight()},
+                         Magnum::Math::Vector2<float>{uvCoords.bottomRight()},
+                         Magnum::Math::Vector2<float>{uvCoords.bottomLeft()}
+        };
+        drawList.AddImageQuad(&texture,
+                              bbox[0], bbox[1], bbox[2], bbox[3],
+                              uvs[0], uvs[1], uvs[2], uvs[3],
+                              IM_COL32_WHITE);
+    }
+}

--- a/src/render/imgui/context.h
+++ b/src/render/imgui/context.h
@@ -13,92 +13,48 @@ namespace render {
                                                const Magnum::Math::Vector2<imgui::Pixels> &center,
                                                imgui::Pixels radius,
                                                ImU32 color,
-                                               imgui::Pixels thickness) {
-        drawList.AddCircle(center, static_cast<float>(radius), color, 0, static_cast<float>(thickness));
-    }
+                                               imgui::Pixels thickness);
 
     template<>
     void drawLine<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
                                              const Magnum::Math::Vector2<imgui::Pixels> &start,
                                              const Magnum::Math::Vector2<imgui::Pixels> &end,
                                              ImU32 color,
-                                             imgui::Pixels thickness) {
-        drawList.AddLine(start, end, color, static_cast<float>(thickness));
-    }
+                                             imgui::Pixels thickness);
 
     template<>
     void drawRectangle<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
                                                   Magnum::Math::Range2D<imgui::Pixels> rectangle,
                                                   ImU32 color,
-                                                  imgui::Pixels thickness) {
-        drawList.AddRect(rectangle.topLeft(), rectangle.bottomRight(), color, 0, 0, static_cast<float>(thickness));
-    }
+                                                  imgui::Pixels thickness);
 
     template<>
     void drawRectangleFilled<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
                                                         Magnum::Math::Range2D<imgui::Pixels> rectangle,
-                                                        ImU32 color) {
-        drawList.AddRectFilled(rectangle.topLeft(), rectangle.bottomRight(), color);
-    }
+                                                        ImU32 color);
 
     template<>
     void drawPolyline<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
                                                  const std::vector<Magnum::Math::Vector2<imgui::Pixels>> &points_,
                                                  ImU32 color,
                                                  imgui::Pixels thickness,
-                                                 int flags) {
-        std::vector<ImVec2> points;
-        std::transform(points_.begin(), points_.end(), std::back_inserter(points), [&](auto &item) {
-            return Magnum::Vector2{item};
-        });
-        drawList.AddPolyline(points.data(), points.size(), color, flags, static_cast<float>(thickness));
-    }
+                                                 int flags);
 
     template<>
     void drawPolylineFilled<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
                                                        std::vector<Magnum::Math::Vector2<imgui::Pixels>> points_,
-                                                       ImU32 color) {
-        std::vector<ImVec2> points;
-        std::transform(points_.begin(), points_.end(), std::back_inserter(points), [&](auto &item) {
-            return item;
-        });
-        drawList.AddConvexPolyFilled(points.data(), points.size(), color);
-    }
+                                                       ImU32 color);
 
     template<>
     void drawText<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
                                              Magnum::Math::Vector2<imgui::Pixels> position,
                                              float fontSize,
                                              ImU32 color,
-                                             const std::string &content) {
-        // TODO: If we want to rotate, we need to move vertices ourselves: https://gist.github.com/carasuca/e72aacadcf6cf8139de46f97158f790f
-        // TODO: Compute centered in a better way (use ImGui::CalcTextSize())
-        drawList.AddText(ImGui::GetFont(), fontSize, position, color, content.c_str());
-        /*
-        Magnum::Vector2 centered{
-                (float) position_.x() - (content.size() * fontSize_ / 4.f),
-                (float) position_.y() - (fontSize_ / 2.f),
-        };
-        auto position = _transform.transformPoint(Magnum::Vector2{centered});
-        float fontSize = (float) fontSize_ * _transform.uniformScaling();
-        drawList.AddText(ImGui::GetFont(), fontSize, position, color, content.c_str());
-         */
-    }
+                                             const std::string &content);
 
     template<>
     void drawImage<ImDrawList, imgui::Pixels>(ImDrawList &drawList,
                                               Magnum::GL::Texture2D &texture,
                                               const Magnum::Math::Range2D<UVCoordinates> &uvCoords,
-                                              const std::array<Magnum::Math::Vector2<imgui::Pixels>, 4> &bbox) {
-        // Draw translated-rotated image: https://github.com/ocornut/imgui/issues/1982
-        ImVec2 uvs[4] = {Magnum::Math::Vector2<float>{uvCoords.topLeft()},
-                         Magnum::Math::Vector2<float>{uvCoords.topRight()},
-                         Magnum::Math::Vector2<float>{uvCoords.bottomRight()},
-                         Magnum::Math::Vector2<float>{uvCoords.bottomLeft()}
-        };
-        drawList.AddImageQuad(&texture,
-                              bbox[0], bbox[1], bbox[2], bbox[3],
-                              uvs[0], uvs[1], uvs[2], uvs[3],
-                              IM_COL32_WHITE);
-    }
+                                              const std::array<Magnum::Math::Vector2<imgui::Pixels>, 4> &bbox);
 }

--- a/src/render/imgui/pixels.hpp
+++ b/src/render/imgui/pixels.hpp
@@ -2,23 +2,20 @@
 
 #include "../../units/named_unit.hpp"
 
-namespace render {
+namespace render::imgui {
+    namespace units {
+        inline constexpr const char impx[] = "impx";
+    }
 
-    namespace imgui {
-        namespace units {
-            inline constexpr const char impx[] = "impx";
+    using Pixels = math::types::NamedUnitT<float, units::impx>;
+
+    namespace units {
+        constexpr Pixels operator "" _impx(long double d) {
+            return Pixels{static_cast<float>(d)};
         }
 
-        using Pixels = math::types::NamedUnitT<float, units::impx>;
-
-        namespace units {
-            constexpr Pixels operator "" _impx(long double d) {
-                return Pixels{static_cast<float>(d)};
-            }
-
-            constexpr Pixels operator "" _impx(unsigned long long d) {
-                return Pixels{static_cast<float>(d)};
-            }
+        constexpr Pixels operator "" _impx(unsigned long long d) {
+            return Pixels{static_cast<float>(d)};
         }
     }
 }

--- a/src/render/imgui/pixels.hpp
+++ b/src/render/imgui/pixels.hpp
@@ -6,7 +6,7 @@ namespace render {
 
     namespace imgui {
         namespace units {
-            static constexpr char impx[] = "impx";
+            inline constexpr const char impx[] = "impx";
         }
 
         using Pixels = math::types::NamedUnitT<float, units::impx>;

--- a/src/units/CMakeLists.txt
+++ b/src/units/CMakeLists.txt
@@ -1,13 +1,20 @@
 
-add_library(units INTERFACE)
+add_library(units
+        degrees.hpp
+        milimeters.cpp
+        milimeters.hpp
+        named_unit.hpp
+        pixels.hpp
+        ratio.hpp
+        )
 set_target_properties(units PROPERTIES
         PUBLIC_HEADER "degrees.hpp;milimeters.hpp;named_unit.hpp;pixels.hpp;ratio.hpp"
         )
 target_link_libraries(units
-        INTERFACE
+        PUBLIC
         Magnum::Primitives
         )
-target_include_directories(units INTERFACE "${CMAKE_CURRENT_LIST_DIR}/..")
+target_include_directories(units PUBLIC "${CMAKE_CURRENT_LIST_DIR}/..")
 
 install(TARGETS units
         PUBLIC_HEADER DESTINATION include/units

--- a/src/units/milimeters.cpp
+++ b/src/units/milimeters.cpp
@@ -1,0 +1,15 @@
+#include "milimeters.hpp"
+
+namespace math {
+
+    template<>
+    types::RatioT<units::m, units::mm, float> ratio<units::m, units::mm, float>() {
+        return types::RatioT<units::m, units::mm, float>{Meters{1.f}, Milimeters{1000.f}};
+    }
+
+    template<>
+    types::RatioT<units::mm, units::m, float> ratio<units::mm, units::m, float>() {
+        return ratio<units::m, units::mm, float>().inverse();
+    }
+
+}

--- a/src/units/milimeters.hpp
+++ b/src/units/milimeters.hpp
@@ -47,12 +47,8 @@ namespace math {
 
     // Some known ratios
     template<>
-    types::RatioT<units::m, units::mm, float> ratio<units::m, units::mm, float>() {
-        return types::RatioT<units::m, units::mm, float>{Meters{1.f}, Milimeters{1000.f}};
-    }
+    types::RatioT<units::m, units::mm, float> ratio<units::m, units::mm, float>();
 
     template<>
-    types::RatioT<units::mm, units::m, float> ratio<units::mm, units::m, float>() {
-        return ratio<units::m, units::mm, float>().inverse();
-    }
+    types::RatioT<units::mm, units::m, float> ratio<units::mm, units::m, float>();
 }

--- a/src/units/milimeters.hpp
+++ b/src/units/milimeters.hpp
@@ -6,8 +6,8 @@
 namespace math {
 
     namespace units {
-        static const char mm[] = "mm";
-        static const char m[] = "m";
+        inline constexpr const char mm[] = "mm";
+        inline constexpr const char m[] = "m";
     }
 
     namespace types {

--- a/src/units/pixels.hpp
+++ b/src/units/pixels.hpp
@@ -5,7 +5,7 @@
 namespace math {
 
     namespace units {
-        static const char px[] = "px";
+        inline constexpr const char px[] = "px";
     }
 
     namespace types {

--- a/src/units/ratio.hpp
+++ b/src/units/ratio.hpp
@@ -60,11 +60,11 @@ namespace math {
     }
 
     /* Template declaration for fixed ratios between known units */
-    template<const char *symbolOrigin, const char *symbolTarget, typename T>
+    inline template<const char *symbolOrigin, const char *symbolTarget, typename T>
     types::RatioT<symbolOrigin, symbolTarget, T> ratio();
 
     /* Creation of custom ratios */
-    template<const char *symbolOrigin, const char *symbolTarget, typename T>
+    inline template<const char *symbolOrigin, const char *symbolTarget, typename T>
     types::RatioT<symbolOrigin, symbolTarget, T> ratio(types::NamedUnitT<T, symbolOrigin> ori, types::NamedUnitT<T, symbolTarget> tgt) {
         // TODO: Check if 'ratio()' exists, in that case: fail and force its usage
         return types::RatioT<symbolOrigin, symbolTarget, T>(ori, tgt);

--- a/src/units/ratio.hpp
+++ b/src/units/ratio.hpp
@@ -60,11 +60,11 @@ namespace math {
     }
 
     /* Template declaration for fixed ratios between known units */
-    inline template<const char *symbolOrigin, const char *symbolTarget, typename T>
+    template<const char *symbolOrigin, const char *symbolTarget, typename T>
     types::RatioT<symbolOrigin, symbolTarget, T> ratio();
 
     /* Creation of custom ratios */
-    inline template<const char *symbolOrigin, const char *symbolTarget, typename T>
+    template<const char *symbolOrigin, const char *symbolTarget, typename T>
     types::RatioT<symbolOrigin, symbolTarget, T> ratio(types::NamedUnitT<T, symbolOrigin> ori, types::NamedUnitT<T, symbolTarget> tgt) {
         // TODO: Check if 'ratio()' exists, in that case: fail and force its usage
         return types::RatioT<symbolOrigin, symbolTarget, T>(ori, tgt);


### PR DESCRIPTION
Using `static constexpr char xxx[];`, these variables have internal linkage and everything using it also has internal linkage. Unit created using them have internal linkage, functions using them have internal linkage,... and we cannot implement those classes/methods in `.cpp` files, we get linkage errors with undefined symbols.  